### PR TITLE
Added missing locale files for Vulp markings

### DIFF
--- a/Resources/Locale/en-US/_DV/markings/vulpkanin.ftl
+++ b/Resources/Locale/en-US/_DV/markings/vulpkanin.ftl
@@ -1,0 +1,255 @@
+marking-VulpEar-vulp = Vulpkanin ears (base)
+marking-VulpEar-vulp-inner = Vulpkanin ears (inner)
+marking-VulpEar = Vulpkanin
+
+marking-VulpEarFade-vulp = Vulpkanin ears (base)
+marking-VulpEarFade-vulp-fade = Vulpkanin ears (fade)
+marking-VulpEarFade = Vulpkanin (fade)
+
+marking-VulpEarSharp-vulp = Vulpkanin ears (base)
+marking-VulpEarSharp-vulp-sharp = Vulpkanin ears (sharp)
+marking-VulpEarSharp = Vulpkanin (sharp)
+
+marking-VulpEarJackal-jackal = Jackal ears (base)
+marking-VulpEarJackal-jackal-inner = Jackal ears (inner)
+marking-VulpEarJackal = Vulpkanin Jackal
+
+marking-VulpEarTerrier-terrier = Terrier ears (base)
+marking-VulpEarTerrier-terrier-inner = Terrier ears (inner)
+marking-VulpEarTerrier = Vulpkanin Terrier
+
+marking-VulpEarWolf-wolf = Wolf ears (base)
+marking-VulpEarWolf-wolf-inner = Wolf ears (inner)
+marking-VulpEarWolf = Vulpkanin Wolf
+
+marking-VulpEarFennec-fennec = Fennec ears (base)
+marking-VulpEarFennec-fennec-inner = Fennec ears (inner)
+marking-VulpEarFennec = Vulpkanin Fennec
+
+marking-VulpEarFox-fox = Fox ears (base)
+marking-VulpEarFox-fox-inner = Fox ears (inner)
+marking-VulpEarFox = Vulpkanin Fox
+
+marking-VulpEarOtie-otie = Otie ears (base)
+marking-VulpEarOtie-otie-inner = Otie ears (inner)
+marking-VulpEarOtie = Vulpkanin Otie
+
+marking-VulpEarTajaran-msai = Tajaran ears (base)
+marking-VulpEarTajaran-msai-inner = Tajaran ears (inner)
+marking-VulpEarTajaran = Vulpkanin Tajaran
+
+marking-VulpEarShock-shock = Shock ears
+marking-VulpEarShock = Vulpkanin Shock
+
+marking-VulpEarCoyote-coyote = Coyote ears
+marking-VulpEarCoyote = Vulpkanin Coyote
+
+marking-VulpEarDalmatian-dalmatian = Dalmatian ears
+marking-VulpEarDalmatian = Vulpkanin Dalmatian
+
+
+marking-VulpSnoutAlt-muzzle_alt = Muzzle
+marking-VulpSnoutAlt-nose = Nose
+marking-VulpSnoutAlt = Vulpkanin Muzzle 2
+
+marking-VulpSnout-muzzle = Muzzle
+marking-VulpSnout-nose = Nose
+marking-VulpSnout = Vulpkanin Muzzle
+
+marking-VulpSnoutSharp-muzzle_sharp = Muzzle
+marking-VulpSnoutSharp-nose = Nose
+marking-VulpSnoutSharp = Vulpkanin Muzzle (sharp)
+
+marking-VulpSnoutFade-muzzle_fade = Muzzle
+marking-VulpSnoutFade-nose = Nose
+marking-VulpSnoutFade = Vulpkanin Muzzle (fade)
+
+marking-VulpSnoutNose-nose = Nose
+marking-VulpSnoutNose = Vulpkanin Nose
+
+marking-VulpSnoutMask-mask = Mask
+marking-VulpSnoutMask-nose = Nose
+marking-VulpSnoutMask = Vulpkanin Mask
+
+marking-VulpSnoutVulpine-vulpine = Vulpine (base)
+marking-VulpSnoutVulpine-vulpine-lines = Vulpine (lines)
+marking-VulpSnoutVulpine = Vulpkanin Vulpine
+
+marking-VulpSnoutSwift-vulpine-lines = Swift
+marking-VulpSnoutSwift = Vulpkanin Swift
+
+marking-VulpSnoutBlaze-blaze = Blaze
+marking-VulpSnoutBlaze = Vulpkanin Blaze
+
+marking-VulpSnoutPatch-patch = Patch
+marking-VulpSnoutPatch = Vulpkanin Patch
+
+
+marking-VulpHeadTiger-tiger_head = Tiger stripes
+marking-VulpHeadTiger = Vulpkanin Tiger stripes (head)
+
+marking-VulpHeadTigerFace-tiger_face = Tiger stripes
+marking-VulpHeadTigerFace = Vulpkanin Tiger stripes (face)
+
+marking-VulpHeadSlash-slash = Slash
+marking-VulpHeadSlash = Vulpkanin Slash
+
+
+marking-VulpTail-vulp = Vulpkanin tail (base)
+marking-VulpTail-vulp-fade = Vulpkanin tail (fade)
+marking-VulpTail = Vulpkanin
+
+marking-VulpTailTip-vulp = Vulpkanin tail (base)
+marking-VulpTailTip-vulp-tip = Vulpkanin tail (tip)
+marking-VulpTailTip = Vulpkanin (tip)
+
+marking-VulpTailWag-vulp_wag = Vulpkanin tail (base)
+marking-VulpTailWag-vulp_wag-fade = Vulpkanin tail (fade)
+marking-VulpTailWag = Vulpkanin (wag)
+
+marking-VulpTailWagTip-vulp_wag = Vulpkanin tail (base)
+marking-VulpTailWagTip-vulp_wag-tip = Vulpkanin tail (tip)
+marking-VulpTailWagTip = Vulpkanin (wag, tip)
+
+marking-VulpTailAlt-vulp_alt = Vulpkanin tail (base)
+marking-VulpTailAlt-vulp_alt-fade = Vulpkanin tail (fade)
+marking-VulpTailAlt = Vulpkanin (alt)
+
+marking-VulpTailAltTip-vulp_alt = Vulpkanin tail (base)
+marking-VulpTailAltTip-vulp_alt-tip = Vulpkanin tail (tip)
+marking-VulpTailAltTip = Vulpkanin (alt, tip)
+
+marking-VulpTailLong-long = Long tail (base)
+marking-VulpTailLong-long-tip = Long tail (tip)
+marking-VulpTailLong = Vulpkanin Long
+
+marking-VulpTailFox-fox = Fox tail (base)
+marking-VulpTailFox-fox-fade = Fox tail (fade)
+marking-VulpTailFox = Vulpkanin Fox
+
+marking-VulpTailFoxTip-fox = Fox tail (base)
+marking-VulpTailFoxTip-fox-tip = Fox tail (fade)
+marking-VulpTailFoxTip = Vulpkanin Fox (tip)
+
+marking-VulpTailFoxWag-fox_wag = Fox tail (base)
+marking-VulpTailFoxWag-fox_wag-fade = Fox tail (fade)
+marking-VulpTailFoxWag = Vulpkanin Fox (wag)
+
+marking-VulpTailFoxWagTip-fox_wag = Fox tail (base)
+marking-VulpTailFoxWagTip-fox_wag-tip = Fox tail (tip)
+marking-VulpTailFoxWagTip = Vulpkanin Fox (wag, tip)
+
+marking-VulpTailBushy-bushfluff = Bush tail
+marking-VulpTailBushy = Vulpkanin Bush
+
+marking-VulpTailBushyWag-bushfluff_wag = Bush tail
+marking-VulpTailBushyWag = Vulpkanin Bush (wag)
+
+marking-VulpTailCoyote-coyote = Coyote tail
+marking-VulpTailCoyote = Vulpkanin Coyote
+
+marking-VulpTailCoyoteWag-coyote_wag = Coyote tail
+marking-VulpTailCoyoteWag = Vulpkanin Coyote (wag)
+
+marking-VulpTailCorgiWag-corgi_wag = Crogi tail
+marking-VulpTailCorgiWag = Vulpkanin Corgi (wag)
+
+marking-VulpTailHusky-husky-inner = Husky tail (inner)
+marking-VulpTailHusky-husky-outer = Husky tail (outer)
+marking-VulpTailHusky = Vulpkanin Husky
+
+marking-VulpTailHuskyAlt-husky = Husky tail
+marking-VulpTailHuskyAlt = Vulpkanin Husky (alt)
+
+marking-VulpTailFox2-fox2 = Fox tail
+marking-VulpTailFox2 = Vulpkanin Fox 2
+
+marking-VulpTailFox3-fox3 = Fox tail (base)
+marking-VulpTailFox3-fox3-tip = Fox tail (tip)
+marking-VulpTailFox3 = Vulpkanin Fox 3
+
+marking-VulpTailFennec-fennec = Fennec tail
+marking-VulpTailFennec = Vulpkanin Fennec
+
+marking-VulpTailOtie-otie = Otie tail
+marking-VulpTailOtie = Vulpkanin Otie
+
+marking-VulpTailFluffy-fluffy = Fluffy tail
+marking-VulpTailFluffy = Vulpkanin Fluffy
+
+marking-VulpTailDalmatianWag-dalmatian_wag = Dalmatian tail
+marking-VulpTailDalmatianWag = Vulpkanin Dalmatian (wag)
+
+
+marking-VulpBellyCrest-belly_crest = Belly
+marking-VulpBellyCrest = Vulpkanin Belly Crest
+
+marking-VulpBellyFull-belly_full = Belly
+marking-VulpBellyFull = Vulpkanin Belly 1
+
+marking-VulpBellyFox-belly_fox = Belly
+marking-VulpBellyFox = Vulpkanin Belly 2
+
+
+marking-VulpBodyPointsCrest-points_crest = Points (crest)
+marking-VulpBodyPointsCrest = Vulpkanin Points (crest)
+
+marking-VulpBodyPointsFade-points_fade = Vulpkanin Points (fade)
+marking-VulpBodyPointsFade = Vulpkanin Points (fade)
+
+marking-VulpBodyPointsSharp-points_sharp = Vulpkanin Points (sharp)
+marking-VulpBodyPointsSharp = Vulpkanin Points (sharp)
+
+
+marking-VulpPointsFeet-points_feet = Points Feet
+marking-VulpPointsFeet = Vulpkanin Points Feet
+
+marking-VulpPointsCrestLegs-points_crest-legs = Points (crest)
+marking-VulpPointsCrestLegs = Vulpkanin Points Legs (crest)
+
+marking-VulpPointsFadeLegs-points_fade-legs = Points (fade)
+marking-VulpPointsFadeLegs = Vulpkanin Points Legs (fade)
+
+marking-VulpPointsSharpLegs-points_sharp-legs = Points (sharp)
+marking-VulpPointsSharpLegs = Vulpkanin Points Legs (sharp)
+
+
+marking-VulpPointsHands-points_hands = Points Hands
+marking-VulpPointsHands = Vulpkanin Points Hands
+
+marking-VulpPointsCrestArms-points_crest-arms = Points (crest)
+marking-VulpPointsCrestArms = Vulpkanin Points Arms (crest)
+
+marking-VulpPointsFadeArms-points_fade-arms = Points (fade)
+marking-VulpPointsFadeArms = Vulpkanin Points Arms (fade)
+
+marking-VulpPointsSharpArms-points_sharp-arms = Points (sharp)
+marking-VulpPointsSharpArms = Vulpkanin Points Arms (sharp)
+
+
+marking-VulpHairAdhara = Adhara
+marking-VulpHairAnita = Anita
+marking-VulpHairApollo = Apollo
+marking-VulpHairBelle = Belle
+marking-VulpHairBraided = Braided Hair
+marking-VulpHairBun = Bun
+marking-VulpHairCleanCut = Clean Cut
+marking-VulpHairCurl = Curl
+marking-VulpHairHawk = Hawk
+marking-VulpHairJagged = Jagged
+marking-VulpHairJeremy = Jeremy
+marking-VulpHairKajam = Kajam
+marking-VulpHairKeid = Keid
+marking-VulpHairKleeia = Kleeia
+marking-VulpHairMizar = Mizar
+marking-VulpHairPunkBraided = Punk Braided
+marking-VulpHairRaine = Raine
+marking-VulpHairRough = Rough
+marking-VulpHairShort = Short Hair
+marking-VulpHairShort2 = Short Hair 2
+marking-VulpHairSpike = Spike
+
+marking-VulpFacialHairRuff = Ruff
+marking-VulpFacialHairElder = Elder
+marking-VulpFacialHairElderChin = Elder Chin
+marking-VulpFacialHairKita = Kita


### PR DESCRIPTION
I accidentally left out the markings locale file for Vulkpkanin. Whoops!

- fix: Vulpkanin markings now use their correct names

