### PR TITLE
Changed the targeted changelog file for discord webhook

### DIFF
--- a/Tools/actions_changelog_rss.py
+++ b/Tools/actions_changelog_rss.py
@@ -46,7 +46,7 @@ FEED_LANGUAGE    = "en-US"
 FEED_GUID_PREFIX = "ss14-changelog-wizards-"
 FEED_URL         = "https://central.spacestation14.io/changelog.xml"
 
-CHANGELOG_FILE = "Resources/Changelog/Changelog.yml"
+CHANGELOG_FILE = "Resources/Changelog/PacificLog.yml"
 
 TYPES_TO_EMOJI = {
     "Fix":    "🐛",


### PR DESCRIPTION
No changelog needed, fixed the discord webhook script to target our changelog instead of upstreams